### PR TITLE
Add safe space promise section to welcome page

### DIFF
--- a/resources/views/partials/safe-space.blade.php
+++ b/resources/views/partials/safe-space.blade.php
@@ -1,0 +1,84 @@
+<section class="relative overflow-hidden rounded-3xl border border-white/10 bg-[#1a1533]/90 p-8 shadow-[0_25px_60px_-30px_rgba(10,6,30,0.95)] backdrop-blur-xl">
+    <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(148,118,255,0.25),_transparent_65%)]"></div>
+    <div class="relative grid gap-8 lg:grid-cols-[1.15fr_0.85fr]">
+        <div class="space-y-6">
+            <header class="space-y-3">
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-white/60">Safe Space Promise</p>
+                <h2 class="text-2xl font-semibold text-white">We hold quiet, courageous conversations.</h2>
+            </header>
+            <p class="max-w-2xl text-sm leading-relaxed text-white/80">
+                Our circle is rooted in consent, curiosity, and gentle accountability. We listen with soft edges,
+                speak from lived experience, and honor the pauses that let every voice feel heard. This dusk-lit
+                corner of the internet is an invitation to arrive exactly as you are.
+            </p>
+            <ul class="grid gap-3 text-sm text-white/85 sm:grid-cols-2">
+                <li class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                    <span class="mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-[#ff8fc7] shadow-[0_0_8px_2px_rgba(255,143,199,0.5)]"></span>
+                    <span>Compassion-first reflections that slow down reaction into response.</span>
+                </li>
+                <li class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                    <span class="mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-[#5f64ff] shadow-[0_0_8px_2px_rgba(95,100,255,0.45)]"></span>
+                    <span>Consent-forward storytelling &mdash; no advice, unless it is asked and welcomed.</span>
+                </li>
+                <li class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                    <span class="mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-[#c4a6ff] shadow-[0_0_8px_2px_rgba(196,166,255,0.45)]"></span>
+                    <span>Boundaries that protect energy, timelines, and our collective nervous systems.</span>
+                </li>
+                <li class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+                    <span class="mt-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-[#ffdda6] shadow-[0_0_8px_2px_rgba(255,221,166,0.4)]"></span>
+                    <span>Celebrations of softness, rest, and the brave act of needing support.</span>
+                </li>
+            </ul>
+        </div>
+        <aside class="space-y-6">
+            <div class="rounded-3xl border border-white/10 bg-[#201944]/75 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)]">
+                <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-white/65">Urgent support</h3>
+                <p class="mt-2 text-sm text-white/75">If you or someone you love needs immediate care, please reach out to the resources below.</p>
+                <ul class="mt-4 space-y-3 text-sm">
+                    <li>
+                        <a href="https://988lifeline.org/" class="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-[#d6cbff] transition-all duration-200 hover:border-[#ff8fc7] hover:bg-[#ff8fc7]/15 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#ff8fc7]">
+                            <span aria-hidden="true" class="text-xs text-white/70 transition-transform duration-200 group-hover:translate-x-0.5">&#9728;</span>
+                            U.S. &amp; Canada: 988 Lifeline
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://www.samaritans.org/how-we-can-help/contact-samaritan/" class="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-[#d6cbff] transition-all duration-200 hover:border-[#ff8fc7] hover:bg-[#ff8fc7]/15 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#ff8fc7]">
+                            <span aria-hidden="true" class="text-xs text-white/70 transition-transform duration-200 group-hover:translate-x-0.5">&#9728;</span>
+                            UK &amp; Ireland: Samaritans 116 123
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://www.lifeline.org.au/" class="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-[#d6cbff] transition-all duration-200 hover:border-[#ff8fc7] hover:bg-[#ff8fc7]/15 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#ff8fc7]">
+                            <span aria-hidden="true" class="text-xs text-white/70 transition-transform duration-200 group-hover:translate-x-0.5">&#9728;</span>
+                            Australia: Lifeline 13 11 14
+                        </a>
+                    </li>
+                </ul>
+            </div>
+            <div class="rounded-3xl border border-white/10 bg-[#201944]/75 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)]">
+                <h3 class="text-sm font-semibold uppercase tracking-[0.25em] text-white/65">Self-serve comforts</h3>
+                <p class="mt-2 text-sm text-white/75">Ground your body and breath with practices you can reach for at any hour.</p>
+                <ul class="mt-4 space-y-3 text-sm">
+                    <li>
+                        <a href="https://insighttimer.com/meditation" class="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-[#d6cbff] transition-all duration-200 hover:border-[#ff8fc7] hover:bg-[#ff8fc7]/15 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#ff8fc7]">
+                            <span aria-hidden="true" class="text-xs text-white/70 transition-transform duration-200 group-hover:translate-x-0.5">&#9728;</span>
+                            Dusk meditations for tender evenings
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://diyjournaling.com/journal-prompts/" class="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-[#d6cbff] transition-all duration-200 hover:border-[#ff8fc7] hover:bg-[#ff8fc7]/15 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#ff8fc7]">
+                            <span aria-hidden="true" class="text-xs text-white/70 transition-transform duration-200 group-hover:translate-x-0.5">&#9728;</span>
+                            Gentle journal prompts for slow mornings
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://open.spotify.com/playlist/37i9dQZF1DX4sWSpwq3LiO" class="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-[#d6cbff] transition-all duration-200 hover:border-[#ff8fc7] hover:bg-[#ff8fc7]/15 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#ff8fc7]">
+                            <span aria-hidden="true" class="text-xs text-white/70 transition-transform duration-200 group-hover:translate-x-0.5">&#9728;</span>
+                            Soft synth rain &amp; lullaby playlist
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </aside>
+    </div>
+</section>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -150,6 +150,8 @@
                             </div>
                         </div>
                     </section>
+
+                    @include('partials.safe-space')
                 </div>
             </main>
         </div>


### PR DESCRIPTION
## Summary
- add a dusk-toned Safe Space Promise section with manifesto content and support resources
- extract the new markup into a reusable `safe-space` partial and include it on the welcome view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e150e61b40832e81887bdef23e40e4