### PR TITLE
Add journal and moonlight message submissions

### DIFF
--- a/app/Http/Controllers/JournalEntryController.php
+++ b/app/Http/Controllers/JournalEntryController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\JournalEntry;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class JournalEntryController extends Controller
+{
+    /**
+     * Store a newly created journal entry.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'title' => ['nullable', 'string', 'max:80'],
+            'mood' => ['required', 'string', Rule::in(['calm', 'wistful', 'curious', 'restless', 'light'])],
+            'quality' => ['required', 'integer', 'between:1,5'],
+            'body' => ['required', 'string', 'max:2000'],
+        ]);
+
+        JournalEntry::create($validated);
+
+        return redirect()
+            ->route('journal')
+            ->with('status', 'Your dream entry was saved.');
+    }
+}

--- a/app/Http/Controllers/MoonlightMessageController.php
+++ b/app/Http/Controllers/MoonlightMessageController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\MoonlightMessage;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class MoonlightMessageController extends Controller
+{
+    /**
+     * Store a newly created moonlight message.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'to' => ['required', 'string', 'max:120'],
+            'topic' => ['required', 'string', Rule::in(['gratitude', 'check-in', 'affirmation', 'invite'])],
+            'subject' => ['nullable', 'string', 'max:80'],
+            'body' => ['required', 'string', 'max:800'],
+        ]);
+
+        MoonlightMessage::create($validated);
+
+        return redirect()
+            ->route('messages')
+            ->with('status', 'Your moonlight message is on its way.');
+    }
+}

--- a/app/Models/JournalEntry.php
+++ b/app/Models/JournalEntry.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class JournalEntry extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'title',
+        'mood',
+        'quality',
+        'body',
+    ];
+}

--- a/app/Models/MoonlightMessage.php
+++ b/app/Models/MoonlightMessage.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MoonlightMessage extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'to',
+        'topic',
+        'subject',
+        'body',
+    ];
+}

--- a/database/migrations/2024_05_28_000001_create_journal_entries_table.php
+++ b/database/migrations/2024_05_28_000001_create_journal_entries_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('journal_entries', function (Blueprint $table) {
+            $table->id();
+            $table->string('title', 80)->nullable();
+            $table->string('mood', 32);
+            $table->unsignedTinyInteger('quality');
+            $table->text('body');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('journal_entries');
+    }
+};

--- a/database/migrations/2024_05_28_000002_create_moonlight_messages_table.php
+++ b/database/migrations/2024_05_28_000002_create_moonlight_messages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('moonlight_messages', function (Blueprint $table) {
+            $table->id();
+            $table->string('to', 120);
+            $table->string('topic', 32);
+            $table->string('subject', 80)->nullable();
+            $table->text('body');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('moonlight_messages');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:1QWy5Di7r+ayv07c975XSNnQi7l/m8F/s4n+0vfZyu8="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Controllers\JournalEntryController;
+use App\Http\Controllers\MoonlightMessageController;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
 use Livewire\Volt\Volt;
@@ -11,6 +13,8 @@ Route::get('/', function () {
 Route::view('/journal', 'journal')->name('journal');
 Route::view('/playlist', 'playlist')->name('playlist');
 Route::view('/messages', 'messages')->name('messages');
+Route::post('/journal', [JournalEntryController::class, 'store'])->name('journal.store');
+Route::post('/messages', [MoonlightMessageController::class, 'store'])->name('messages.store');
 
 Route::view('dashboard', 'dashboard')
     ->middleware(['auth', 'verified'])

--- a/tests/Feature/JournalEntrySubmissionTest.php
+++ b/tests/Feature/JournalEntrySubmissionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class JournalEntrySubmissionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_journal_entry_can_be_stored(): void
+    {
+        $payload = [
+            'title' => 'Glowing Tides',
+            'mood' => 'calm',
+            'quality' => 4,
+            'body' => 'I walked across shimmering water and the stars hummed softly.',
+        ];
+
+        $response = $this->post(route('journal.store'), $payload);
+
+        $response->assertStatus(302)->assertRedirect(route('journal'));
+        $response->assertSessionHas('status');
+
+        $this->assertDatabaseHas('journal_entries', [
+            'title' => 'Glowing Tides',
+            'mood' => 'calm',
+            'quality' => 4,
+        ]);
+    }
+}

--- a/tests/Feature/MoonlightMessageSubmissionTest.php
+++ b/tests/Feature/MoonlightMessageSubmissionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MoonlightMessageSubmissionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_moonlight_message_can_be_stored(): void
+    {
+        $payload = [
+            'to' => '@dawn',
+            'topic' => 'gratitude',
+            'subject' => 'Morning Stars',
+            'body' => 'Thank you for always meeting me before sunrise.',
+        ];
+
+        $response = $this->post(route('messages.store'), $payload);
+
+        $response->assertStatus(302)->assertRedirect(route('messages'));
+        $response->assertSessionHas('status');
+
+        $this->assertDatabaseHas('moonlight_messages', [
+            'to' => '@dawn',
+            'topic' => 'gratitude',
+            'subject' => 'Morning Stars',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- wire journal and moonlight message forms to dedicated POST routes and controllers
- persist submitted entries/messages in new tables and Eloquent models with validation and flash feedback
- add feature tests for both flows and configure the testing APP_KEY

## Testing
- php artisan test --filter=JournalEntrySubmissionTest
- php artisan test --filter=MoonlightMessageSubmissionTest

------
https://chatgpt.com/codex/tasks/task_e_68e162ae109c832ebd3b89ca3faba7bb